### PR TITLE
Improve README usage guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,51 @@ await Promise.all(items.map(async (item: string) => {
 }));
 ```
 
+## Usage
+
+Semaphores are useful whenever a piece of code must run with a limited
+concurrency level or with exclusive access to a shared resource. This library
+implements a FIFO semaphore, so the oldest pending `acquire()` call is the next
+one to receive a permit.
+
+### Limit parallelism of async work
+
+```ts
+const semaphore = new Semaphore(3);
+
+async function fetchWithLimit(url: string) {
+  const release = await semaphore.acquire();
+  try {
+    const response = await fetch(url);
+    return await response.json();
+  } finally {
+    release();
+  }
+}
+
+const results = await Promise.all(urls.map(fetchWithLimit));
+```
+
+### Guard access to a critical section
+
+```ts
+const semaphore = new Semaphore(1);
+
+async function withExclusiveAccess<T>(fn: () => Promise<T>): Promise<T> {
+  const release = await semaphore.acquire();
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+await withExclusiveAccess(() => connection.query("BEGIN"));
+```
+
+Keep the critical section as small as possible and always call `release()` in a
+`finally` block. The releaser is idempotent, so extra calls are ignored.
+
 ## API
 
 ### `new Semaphore(permits: number)`


### PR DESCRIPTION
## Summary
- add a usage section to README with patterns for limiting concurrency and guarding critical sections
- document best practices for releasing permits

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c85ce198cc8327b944a6641c0dd7be