### PR TITLE
Simplify documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # @hortemo/semaphore
 
-A promise-based FIFO semaphore for JavaScript/TypeScript.
+Promise-based FIFO semaphore for JavaScript and TypeScript.
 
-## Installation
+## Install
 
 ```bash
 npm install @hortemo/semaphore
 ```
 
-## Quick start
+## Use
 
 ```ts
 import Semaphore from "@hortemo/semaphore";
@@ -27,18 +27,8 @@ async function processItem(item: string): Promise<void> {
 await Promise.all(items.map(processItem));
 ```
 
-## API reference
+## API
 
-### `new Semaphore(permits: number)`
-
-Creates a semaphore with the given number of **permits**.
-
-### `semaphore.acquire(): Promise<Releaser>`
-
-Asynchronously waits for a permit. The returned promise resolves with a
-`Releaser` function. Call it once you are done with the permit. Extra calls to
-the same `Releaser` are ignored.
-
-### `type Releaser = () => void`
-
-The function returned by `acquire()`. Invoke it to return the permit.
+- `new Semaphore(permits: number)`: create a semaphore with `permits` available. `permits` must be a non-negative integer.
+- `await semaphore.acquire()`: wait for a permit and receive a `Releaser`. Call it once to free the permit.
+- `type Releaser = () => void`: invoke to return the permit.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,33 +1,16 @@
-/**
- * A function returned by {@link Semaphore.acquire}. Call it once to return the
- * permit you previously acquired. Extra calls are ignored.
- */
+/** Function returned by {@link Semaphore.acquire}. Call once to return the permit. */
 export type Releaser = () => void;
 
-/**
- * A promise-based FIFO semaphore.
- *
- * Basic usage:
- * ```ts
- * const semaphore = new Semaphore(5);
- *
- * const release = await semaphore.acquire();
- * try {
- *   await doWork();
- * } finally {
- *   release();
- * }
- * ```
- */
+/** Promise-based FIFO semaphore. */
 export default class Semaphore {
   private _permits: number;
   private _waitQueue: Array<() => void> = [];
 
   /**
-   * Create a semaphore with the given number of permits.
+   * Create a semaphore.
    *
-   * @param permits Initial number of permits. Must be a non-negative integer.
-   * @throws {Error} If `permits` is not a positive integer.
+   * @param permits Non-negative initial permit count.
+   * @throws {Error} If `permits` is not a non-negative integer.
    */
   constructor(permits: number) {
     if (!Number.isInteger(permits) || permits < 0) {
@@ -36,13 +19,7 @@ export default class Semaphore {
     this._permits = permits;
   }
 
-  /**
-   * Wait for a permit and resolve with a {@link Releaser}.
-   *
-   * The returned promise settles as soon as the semaphore can grant a permit.
-   * Once your work is complete, invoke the releaser to return the permit to
-   * the pool so the next waiter can continue.
-   */
+  /** Resolve with a {@link Releaser} when a permit is available. Call it once to return the permit. */
   public acquire(): Promise<Releaser> {
     return new Promise<Releaser>((resolve) => {
       this._waitQueue.push(() => {


### PR DESCRIPTION
## Summary
- tighten the README wording and reorganize the API overview into concise bullets
- streamline inline TypeScript documentation for the semaphore and releaser types

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c86690b3148327bd9df24db42ce35b